### PR TITLE
Launcher should wait for AkelUpdater.exe

### DIFF
--- a/App/AppInfo/Launcher/AkelPadPortable.ini
+++ b/App/AppInfo/Launcher/AkelPadPortable.ini
@@ -1,6 +1,7 @@
 [Launch]
 ProgramExecutable=AkelPad\AkelPad.exe
 ProgramExecutable64=AkelPadx64\AkelPad.exe
+WaitForEXE1=AkelUpdater.exe
 DirectoryMoveOK=yes
 SupportsUNC=yes
 


### PR DESCRIPTION
Updating plugins, scripts, or AkelPad itself through the built-in updater and allowing the updater to relaunch AkelPad (checkbox is checked by default) will break the app out of portable mode. Adding WaitForEXE1=AkelUpdater.exe prevents this.
